### PR TITLE
change "btct" to "tbtc"

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Select the coin to query for by specifying the associated subdomain.
 The default is bitcoin (btc).
 
 	Blockr.setCoinSubdomain("btc");	// Bitcoin
-	Blockr.setCoinSubdomain("btct"); // Bitcoin (Testnet)
+	Blockr.setCoinSubdomain("tbtc"); // Bitcoin (Testnet)
 	Blockr.setCoinSubdomain("ltc"); // litecoin
 	Blockr.setCoinSubdomain("dgc"); // Digitalcoin
 	Blockr.setCoinSubdomain("qrk"); // Quark

--- a/blockr.js
+++ b/blockr.js
@@ -3,7 +3,7 @@
 
 var Blockr = (function() {
   // Different coin info is retrieved via different subdomains
-  var COIN_SUBDOMAINS = [ "btc", "btct", "ltc", "dgc", "qrk", "ppc", "mec" ];
+  var COIN_SUBDOMAINS = [ "btc", "tbtc", "ltc", "dgc", "qrk", "ppc", "mec" ];
   
   // Used to construct query urls for v1 of the API
   var V1_URL_FRAGMENT = ".blockr.io/api/v1";


### PR DESCRIPTION
Hi,

FYI: I used your lib today to access blockr directly from the browser and it works (as blockr uses the correct CORS settings) -> https://raw.githack.com/DanielWeigl/bip39/master/src/index.html (the "Fetch" button)

And I noticed that you had the wrong coin-code for Bitcoin Testnet -> see attached changes.
